### PR TITLE
Add possibility to do custom searches

### DIFF
--- a/djangoql/schema.py
+++ b/djangoql/schema.py
@@ -11,6 +11,32 @@ from .compat import text_type
 from .exceptions import DjangoQLSchemaError
 
 
+class DjangoQLField(object):
+    """
+    Represents searchable field.
+    """
+    def __init__(self, name, type, relation, related_model,
+                 nullable, options, search=None):
+        self.name = name
+        self.type = type
+        self.relation = relation
+        self.related_model = related_model
+        self.nullable = nullable
+        self.options = options
+        self.search = search
+
+    def as_dict(self):
+        return {
+            'type': self.type,
+            'relation': self.relation,
+            'nullable': self.nullable,
+            'options': self.options
+        }
+
+    def add_search_target(self, queryset):
+        return queryset
+
+
 class DjangoQLSchema(object):
     include = ()  # models to include into introspection
     exclude = ()  # models to exclude from introspection
@@ -50,47 +76,58 @@ class DjangoQLSchema(object):
     def model_label(self, model):
         return text_type(model._meta)
 
+    def get_field_spec(self, model, field_name):
+        field = model._meta.get_field(field_name)
+        if field.is_relation:
+            if not field.related_model:
+                # GenericForeignKey
+                return
+            if self.excluded(field.related_model):
+                return
+            field_type = 'relation'
+            relation = self.model_label(field.related_model)
+        else:
+            field_type = self.get_field_type(field)
+            relation = None
+        if field_type == 'str':
+            options = self.get_options(model, field_name) or []
+        else:
+            options = []
+        if isinstance(field, (ManyToOneRel, ManyToManyRel)):
+            # Django 1.8 doesn't have .null attribute for these fields
+            nullable = True
+        else:
+            nullable = field.null
+        return DjangoQLField(
+            name=field.name,
+            type=field_type,
+            relation=relation,
+            related_model=relation and field.related_model,
+            nullable=nullable,
+            options=list(options),
+        )
+
     def introspect(self, model, exclude=()):
         """
         Start with given model and recursively walk through its relationships.
-        
-        Returns a dict with all model labels and their fields found.   
+
+        Returns a dict with all model labels and their fields found.
         """
         fields = OrderedDict()
         result = {self.model_label(model): fields}
-        for field_name in self.get_fields(model):
-            field = model._meta.get_field(field_name)
-            if field.is_relation:
-                if not field.related_model:
-                    # GenericForeignKey
-                    continue
-                if self.excluded(field.related_model):
-                    continue
-                field_type = 'relation'
-                relation = self.model_label(field.related_model)
-                if relation not in exclude:
-                    result.update(self.introspect(
-                        model=field.related_model,
-                        exclude=tuple(exclude) + tuple(result.keys()),
-                    ))
+        for field_name_or_spec in self.get_fields(model):
+            if isinstance(field_name_or_spec, DjangoQLField):
+                spec = field_name_or_spec
             else:
-                field_type = self.get_field_type(field)
-                relation = None
-            if field_type == 'str':
-                options = self.get_options(model, field_name) or []
-            else:
-                options = []
-            if isinstance(field, (ManyToOneRel, ManyToManyRel)):
-                # Django 1.8 doesn't have .null attribute for these fields
-                nullable = True
-            else:
-                nullable = field.null
-            fields[field.name] = {
-                'type': field_type,
-                'relation': relation,
-                'nullable': nullable,
-                'options': list(options),
-            }
+                spec = self.get_field_spec(model, field_name_or_spec)
+            if not spec:
+                continue
+            fields[spec.name] = spec
+            if spec.relation and spec.relation not in exclude:
+                result.update(self.introspect(
+                    model=spec.related_model,
+                    exclude=tuple(exclude) + tuple(result.keys()),
+                ))
         return result
 
     def get_fields(self, model):
@@ -132,10 +169,35 @@ class DjangoQLSchema(object):
         """
 
     def as_dict(self):
+        def explode(models):
+            result = {}
+            for key, inner_dict in models.items():
+                result[key] = OrderedDict(
+                    [(inner_key, inner_value.as_dict())
+                     for inner_key, inner_value in inner_dict.items()])
+            return result
+
         return {
             'current_model': self.model_label(self.current_model),
-            'models': self.models,
+            'models': explode(self.models),
         }
+
+    def path_to_field(self, path):
+        model = self.model_label(self.current_model)
+        field = None
+        for name_part in path:
+            field = self.models[model].get(name_part)
+            if not field:
+                raise DjangoQLSchemaError(
+                    'Unknown field: %s. Possible choices are: %s' % (
+                        name_part,
+                        ', '.join(sorted(self.models[model].keys())),
+                    )
+                )
+            if field.type == 'relation':
+                model = field.relation
+                field = None
+        return field
 
     def validate(self, node):
         """
@@ -151,20 +213,7 @@ class DjangoQLSchema(object):
         assert isinstance(node.right, (Const, List))
 
         # resolve name
-        model = self.model_label(self.current_model)
-        field = None
-        for name_part in node.left.parts:
-            field = self.models[model].get(name_part)
-            if not field:
-                raise DjangoQLSchemaError(
-                    'Unknown field: %s. Possible choices are: %s' % (
-                        name_part,
-                        ', '.join(sorted(self.models[model].keys())),
-                    )
-                )
-            if field['type'] == 'relation':
-                model = field['relation']
-                field = None
+        field = self.path_to_field(node.left.parts)
 
         # Check that field and value types are compatible
         value = node.right.value
@@ -175,7 +224,7 @@ class DjangoQLSchema(object):
                     '%s' % (node.left.value, type(value).__name__)
                 )
         else:
-            if not field['nullable'] and value is None:
+            if not field.nullable and value is None:
                 raise DjangoQLSchemaError(
                     'Field %s is not nullable, '
                     'can\'t compare it to None' % node.left.value
@@ -187,7 +236,7 @@ class DjangoQLSchema(object):
                 'bool': ['bool'],
                 'date': [text_type.__name__],
                 'datetime': [text_type.__name__],
-            }[field['type']]
+            }[field.type]
             possible_values = {
                 'int': 'integer numbers',
                 'float': 'floating point numbers',
@@ -195,11 +244,11 @@ class DjangoQLSchema(object):
                 'bool': 'True or False',
                 'date': 'dates in "YYYY-MM-DD" format',
                 'datetime': 'timestamps in "YYYY-MM-DD HH:MM" format',
-            }[field['type']]
+            }[field.type]
             values = value if isinstance(node.right, List) else [value]
             for v in values:
                 if v is not None and type(v).__name__ not in possible_types:
-                    if field['nullable']:
+                    if field.nullable:
                         msg = (
                             'Field "{field}" has "nullable {field_type}" type. '
                             'It can be compared to {possible_values} or None, '
@@ -213,12 +262,12 @@ class DjangoQLSchema(object):
                         )
                     raise DjangoQLSchemaError(msg.format(
                         field=node.left.value,
-                        field_type=field['type'],
+                        field_type=field.type,
                         possible_values=possible_values,
                         value=repr(v),
                     ))
                 # validate dates
-                if field['type'] == 'date':
+                if field.type == 'date':
                     try:
                         datetime.strptime(v, '%Y-%m-%d')
                     except ValueError:
@@ -229,7 +278,7 @@ class DjangoQLSchema(object):
                                 repr(v),
                             )
                         )
-                elif field['type'] == 'datetime':
+                elif field.type == 'datetime':
                     mask = '%Y-%m-%d'
                     if len(v) > 10:
                         mask += ' %H:%M'

--- a/test_project/core/tests/test_queryset.py
+++ b/test_project/core/tests/test_queryset.py
@@ -2,8 +2,35 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 
 from djangoql.queryset import apply_search
+from djangoql.schema import DjangoQLField, DjangoQLSchema
 
 from ..models import Book
+
+
+class WrittenInYearSearch(DjangoQLField):
+    def __init__(self):
+        super(WrittenInYearSearch, self).__init__(
+            name='written_in_year',
+            type='int',
+            relation=None,
+            related_model=None,
+            nullable=False,
+            options=[]
+        )
+
+    def add_search_target(self, queryset):
+        from django.db.models.expressions import RawSQL
+        return queryset.annotate(
+            written_in_year=RawSQL('EXTRACT(YEAR FROM written)', [])
+        )
+
+
+class BookCustomSearchSchema(DjangoQLSchema):
+    def get_fields(self, model):
+        if model == Book:
+            return [
+                WrittenInYearSearch()
+            ]
 
 
 class DjangoQLQuerySetTest(TestCase):
@@ -22,3 +49,10 @@ class DjangoQLQuerySetTest(TestCase):
             qs.count()
         except Exception as e:
             self.fail(e)
+
+    def test_custom_field_query(self):
+        qs = Book.objects.djangoql(
+            'written_in_year = 2017',
+            schema=BookCustomSearchSchema)
+        where_clause = str(qs.query).split('WHERE')[1].strip()
+        self.assertEqual(where_clause, "(EXTRACT(YEAR FROM written)) = 2017")

--- a/test_project/core/tests/test_schema.py
+++ b/test_project/core/tests/test_schema.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from djangoql.exceptions import DjangoQLSchemaError
 from djangoql.parser import DjangoQLParser
-from djangoql.schema import DjangoQLSchema
+from djangoql.schema import DjangoQLSchema, DjangoQLField
 
 from ..models import Book
 
@@ -27,6 +27,29 @@ class BookCustomFieldsSchema(DjangoQLSchema):
         if model == Book:
             return ['name', 'is_published']
         return super(BookCustomFieldsSchema, self).get_fields(model)
+
+
+class WrittenInYearSearch(DjangoQLField):
+    def __init__(self):
+        super(WrittenInYearSearch, self).__init__(
+            name='written_in_year',
+            type='str',
+            relation=None,
+            related_model=None,
+            nullable=False,
+            options=[]
+        )
+
+        def search(self, queryset, operator, value):
+            return
+
+
+class BookCustomSearchSchema(DjangoQLSchema):
+    def get_fields(self, model):
+        if model == Book:
+            return [
+                WrittenInYearSearch()
+            ]
 
 
 class DjangoQLSchemaTest(TestCase):
@@ -81,6 +104,10 @@ class DjangoQLSchemaTest(TestCase):
             'written',
         ])
         self.assertListEqual(list(custom.keys()), ['name', 'is_published'])
+
+    def test_custom_search(self):
+        custom = BookCustomSearchSchema(Book).as_dict()['models']['core.book']
+        self.assertListEqual(list(custom.keys()), ['written_in_year'])
 
     def test_invalid_config(self):
         try:


### PR DESCRIPTION
The idea comes in two parts. First, introduce DjangoQLField object, which represents a searchable field. By default this is a model field, but as the added tests show, this can also be something that doesn't exist on the model.

The second part is that DjangoQLField has method add_search_target() which allows one to do custom annotation on the queryset. When there exists an annotation, it's then possible to just use ordinary .filter() on the queryset.

This is related to issue https://github.com/ivelum/djangoql/issues/3