### PR TITLE
Fix AttributeError: on  'GenericRel' object  

### DIFF
--- a/djangoql/schema.py
+++ b/djangoql/schema.py
@@ -80,7 +80,7 @@ class DjangoQLSchema(object):
                 options = self.get_options(model, field_name) or []
             else:
                 options = []
-            if isinstance(field, (ManyToOneRel, ManyToManyRel)):
+            if isinstance(field, (ManyToOneRel, ManyToManyRel, GenericRel)):
                 # Django 1.8 doesn't have .null attribute for these fields
                 nullable = True
             else:

--- a/djangoql/schema.py
+++ b/djangoql/schema.py
@@ -2,6 +2,14 @@ import inspect
 from collections import OrderedDict
 from datetime import datetime
 
+
+try:
+    # Django 1.7
+    from django.contrib.contenttypes.fields import GenericRel
+except ImportError:
+    from django.contrib.contenttypes.generic import GenericRel
+
+    
 from django.db.models import AutoField, BooleanField, CharField, DateField, \
     DateTimeField, DecimalField, FloatField, IntegerField, ManyToOneRel, \
     ManyToManyRel, Model, NullBooleanField, TextField


### PR DESCRIPTION
`AttributeError: 'GenericRel' object has no attribute 'null'` using Django 1.8.x