### PR TITLE
[Feat] if we have choices on str field, than use it

### DIFF
--- a/djangoql/schema.py
+++ b/djangoql/schema.py
@@ -147,6 +147,12 @@ class StrField(DjangoQLField):
     value_types = [text_type]
     value_types_description = 'strings'
 
+    def get_options(self):
+        choices = self.model._meta.get_field(self.name).choices
+        if choices:
+            return [x[0] for x in choices]
+        return super(DjangoQLField, self).get_options()
+
 
 class BoolField(DjangoQLField):
     type = 'bool'


### PR DESCRIPTION
There is an use case, when on suggest_options = True DjangoQL doing SQL for distinct values, but those values are defined in field by parameter choices.
I've implemented to use this property, but don't know if it is solid solution.