### PR TITLE
Use the Media class rather than media property for Django 2.0 compat

### DIFF
--- a/djangoql/admin.py
+++ b/djangoql/admin.py
@@ -35,20 +35,18 @@ class DjangoQLSearchMixin(object):
         messages.add_message(request, messages.WARNING, msg)
         return queryset, use_distinct
 
-    @property
-    def media(self):
-        media = super(DjangoQLSearchMixin, self).media
-        if self.djangoql_completion:
-            media.add_js((
-                'djangoql/js/lib/lexer.js',
-                'djangoql/js/completion.js',
-                'djangoql/js/completion_admin.js',
-            ))
-            media.add_css({'': (
+    class Media:
+        js = (
+            'djangoql/js/lib/lexer.js',
+            'djangoql/js/completion.js',
+            'djangoql/js/completion_admin.js',
+        )
+        css = {
+            'all': (
                 'djangoql/css/completion.css',
                 'djangoql/css/completion_admin.css',
-            )})
-        return media
+            )
+        }
 
     def get_urls(self):
         custom_urls = []


### PR DESCRIPTION
Django 2.0 introduced changes that the media property on the admin forms worked, this resulted in static not being included when djangoql is used.

Changing the media files to use the `Media` class rather than the property fixes this.

https://docs.djangoproject.com/en/2.0/topics/forms/media/#order-of-assets

> In older versions, the assets of Media objects are concatenated rather than merged in a way that tries to preserve the relative ordering of the elements in each list.