### PR TITLE
Prepare for RPM Packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include djangoql/static *
 recursive-include djangoql/templates *
+recursive-include test_project *
 include README.rst LICENSE

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-os.environ['PYTHONDONTWRITEBYTECODE'] = '1'
 
 packages = ['djangoql']
 requires = ['ply>=3.8']
@@ -38,4 +37,3 @@ setup(
     ],
 )
 
-del os.environ['PYTHONDONTWRITEBYTECODE']


### PR DESCRIPTION
Do changes to allow for RPM packaging.

Changes:
* `PYTHONDONTWRITEBYTECODE` removed from setup -- RPM pre-compiles python code
* included tests into sdist package (*) -- to allow testing in RPM build

(*) since there are no version tags in the GitHub repo

Thank you.