### PR TITLE
Document django.contrib.contenttypes Requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ Add ``'djangoql'`` to ``INSTALLED_APPS`` in your ``settings.py``:
 
     INSTALLED_APPS = [
         ...
+        'django.contrib.contenttypes',
         'djangoql',
         ...
     ]


### PR DESCRIPTION
```
  File "/venv/lib64/python3.6/site-packages/djangoql/queryset.py", line 5, in <module>
    from .schema import DjangoQLField, DjangoQLSchema
  File "/venv/lib64/python3.6/site-packages/djangoql/schema.py", line 7, in <module>
    from django.contrib.contenttypes.fields import GenericRel
  File "/venv/lib64/python3.6/site-packages/django/contrib/contenttypes/fields.py", line 3, in <module>
    from django.contrib.contenttypes.models import ContentType
  File "/venv/lib64/python3.6/site-packages/django/contrib/contenttypes/models.py", line 134, in <module>
    class ContentType(models.Model):
  File "/venv/lib64/python3.6/site-packages/django/db/models/base.py", line 95, in __new__
    "INSTALLED_APPS." % (module, name)
RuntimeError: Model class django.contrib.contenttypes.models.ContentType doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```