### PR TITLE
emit submit event before submitting the form

### DIFF
--- a/djangoql/static/djangoql/js/completion.js
+++ b/djangoql/static/djangoql/js/completion.js
@@ -387,6 +387,7 @@
             // feature, but other than that it should look and behave like
             // a normal input. So expected behavior when pressing Enter is
             // to submit the form, not to add a new line.
+            e.target.form.dispatchEvent(new Event('submit'));
             e.target.form.submit();
           }
           e.preventDefault();


### PR DESCRIPTION
to allow JS frameworks to caught the submit, since the [`Form.submit()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit) does
not generate the event.