### PR TITLE
allow to pass HTMLElement through selector

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -472,7 +472,8 @@ Template code, ``completion_demo.html``:
             // or an URL from which this information could be loaded asynchronously
             introspections: {{ introspections|safe }},
 
-            // css selector for query input. It should be a textarea
+            // css selector for query input or HTMLElement object.
+            // It should be a textarea
             selector: 'textarea[name=q]',
 
             // optional, you can provide URL for Syntax Help link here.

--- a/djangoql/static/djangoql/js/completion.js
+++ b/djangoql/static/djangoql/js/completion.js
@@ -136,7 +136,11 @@
       return;
     }
     this.loadIntrospections(options.introspections);
-    this.textarea = document.querySelector(options.selector);
+    if (typeof options.selector === 'string') {
+      this.textarea = document.querySelector(options.selector);
+    } else {
+      this.textarea = options.selector;
+    }
     if (!this.textarea) {
       this.logError('Element not found by selector: ' + options.selector);
       return;


### PR DESCRIPTION
to allow JS frameworks (such as AngularJS) to add djangoQL capabilities (through directives).

From AngularJS or jQuery the element can be passed with:
```
// var element = $("selector")
selector: element.get(0)
```