### PR TITLE
add destroyCompletionElement method

### DIFF
--- a/djangoql/static/djangoql/js/completion.js
+++ b/djangoql/static/djangoql/js/completion.js
@@ -553,6 +553,10 @@
       this.completion.style.display = 'block';
     },
 
+    destroyCompletionElement: function() {
+      this.completion.parentNode.removeChild(this.completion);
+    },
+
     resolveName: function (name) {
       // Walk through introspection definitions and get target model and field
       var f;


### PR DESCRIPTION
to destroy `div.djangoql-completion` appended to `body` on single-page applications.