### PR TITLE
fix schema for model with relation to self

### DIFF
--- a/djangoql/schema.py
+++ b/djangoql/schema.py
@@ -332,7 +332,10 @@ class DjangoQLSchema(object):
         Returns a dict with all model labels and their fields found.
         """
         fields = OrderedDict()
-        result = {self.model_label(model): fields}
+        model_label = self.model_label(model)
+        result = {model_label: fields}
+        exclude += (model_label, )  # exclude self
+
         for field in self.get_fields(model):
             if not isinstance(field, DjangoQLField):
                 field = self.get_field_instance(model, field)

--- a/test_project/core/models.py
+++ b/test_project/core/models.py
@@ -34,4 +34,6 @@ class Book(models.Model):
     object_id = models.PositiveIntegerField(null=True)
     content_object = GenericForeignKey('content_type', 'object_id')
 
+    similar_books = models.ManyToManyField('Book')
+
     objects = DjangoQLQuerySet.as_manager()


### PR DESCRIPTION
Fields from recursive introspections were overwritten, since the parent model was not excluded.

Example is provided in the test.