### PR TITLE
fix TypeError: field is null

### DIFF
--- a/djangoql/static/djangoql/js/completion.js
+++ b/djangoql/static/djangoql/js/completion.js
@@ -785,7 +785,10 @@
           break;
 
         case 'value':
-          if (field.type === 'str') {
+          if (!field) {
+            // related field
+            this.suggestions = [suggestion('None', '', ' ')];
+          } else if (field.type === 'str') {
             if (textBefore && textBefore[textBefore.length - 1] === '"') {
               snippetBefore = '';
             } else {


### PR DESCRIPTION
Fixes completion in case of unknown field, especially common when using
related field.  Note, that related field is not a part of main model.
Adds `None` suggestion for related field usage.

Error:
```
TypeError: field is null    completion.js:789:11
generateSuggestions         static/djangoql/js/completion.js:789:11
selectCompletion            static/djangoql/js/completion.js:479:7
onKeydown                   static/djangoql/js/completion.js:406:13
```

Input Example:
```
related_set = [ENTER]
```
Applies new line to text area because of error -- it does not get to `preventDefault()`