### PR TITLE
Reset suggestions for field of unknown type

### DIFF
--- a/djangoql/static/djangoql/js/completion.js
+++ b/djangoql/static/djangoql/js/completion.js
@@ -815,6 +815,10 @@
             if (field.nullable) {
               this.suggestions.push(suggestion('None', '', ' '));
             }
+          } else if (field.type === 'unknown') {
+            // unknown field type, reset suggestions
+            this.prefix = '';
+            this.suggestions = [];
           }
           break;
 


### PR DESCRIPTION
If a field of unknown type is typed, the operand suggestions are shown second time. This should reset the suggestions after operand.

This is to avoid:
```
unknown_type_field = =
```