### PR TITLE
Fix related field removals when refenced more times

### DIFF
--- a/test_project/core/models.py
+++ b/test_project/core/models.py
@@ -35,7 +35,7 @@ class Book(models.Model):
     object_id = models.PositiveIntegerField(null=True, editable=False)
     content_object = GenericForeignKey('content_type', 'object_id')
 
-    similar_books = models.ManyToManyField('Book', blank=True)
+    similar_books = models.ManyToManyField('Book', blank=True, related_name='+')
 
     objects = DjangoQLQuerySet.as_manager()
 

--- a/test_project/core/tests/test_schema.py
+++ b/test_project/core/tests/test_schema.py
@@ -95,6 +95,7 @@ class DjangoQLSchemaTest(TestCase):
             'object_id',
             'price',
             'rating',
+            'similar_books',
             'written',
         ])
         self.assertListEqual(list(custom.keys()), ['name', 'is_published'])


### PR DESCRIPTION
Fixes removal/override of related fields in schema, when the referenced model is linked from more parent models on multiple levels.  BFS algorithm was chosen.

Example of relations:
```
         M
       /   \
      A     B
     /       \
    B        (C)
   /
  C
```
In current state, the field pointing to model `C` will be removed. This is because model `C` was is excluded (from the first pass of the tree, left one). 