### PR TITLE
Disable yacc write_tables to prevent warnings/errors down the line

### DIFF
--- a/djangoql/parser.py
+++ b/djangoql/parser.py
@@ -36,6 +36,7 @@ class DjangoQLParser(object):
         self.default_lexer = DjangoQLLexer()
         self.tokens = self.default_lexer.tokens
         kwargs['debug'] = debug
+        kwargs['write_tables'] = False
         self.yacc = yacc.yacc(module=self, **kwargs)
 
     def parse(self, input=None, lexer=None, **kwargs):


### PR DESCRIPTION
When djangoql is used within an application which gets installed in a system location (unwritable by
the application itself), yacc command fails with a traceback:
```
  File "/usr/lib/python3.9/site-packages/djangoql/queryset.py", line 36, in apply_search
    ast = DjangoQLParser().parse(search)
  File "/usr/lib/python3.9/site-packages/djangoql/parser.py", line 39, in __init__
    self.yacc = yacc.yacc(module=self, **kwargs)
  File "/usr/lib/python3.9/site-packages/ply/yacc.py", line 3488, in yacc
    errorlog.warning("Couldn't create %r. %s" % (tabmodule, e))
  File "/usr/lib/python3.9/site-packages/ply/yacc.py", line 118, in warning
    self.f.write('WARNING: ' + (msg % args) + '\n')
BrokenPipeError: [Errno 32] Broken pipe
```
This because yacc tries to write to this location:
```
  File "/usr/lib/python3.9/site-packages/ply/yacc.py", line 3484, in yacc
    lr.write_table(tabmodule, outputdir, signature)
  File "/usr/lib/python3.9/site-packages/ply/yacc.py", line 2734, in write_table
    f = open(filename, 'w')
PermissionError: [Errno 13] Permission denied: '/usr/lib/python3.9/site-packages/djangoql/parsetab.py'
```

Adding write_tables=False will disable this behaviour making the error go away