### PR TITLE
Missing fields when model is ref'd more than once

### DIFF
--- a/djangoql/schema.py
+++ b/djangoql/schema.py
@@ -370,10 +370,8 @@ class DjangoQLSchema(object):
                     continue
                 if isinstance(field, RelationField):
                     if field.relation not in closed_set:
-                        model_fields[field.name] = field
                         open_set.append(field.related_model)
-                else:
-                    model_fields[field.name] = field
+                model_fields[field.name] = field
 
             result[model_label] = model_fields
             closed_set.append(model_label)

--- a/test_project/core/tests/test_schema.py
+++ b/test_project/core/tests/test_schema.py
@@ -108,12 +108,12 @@ class DjangoQLSchemaTest(TestCase):
 
     def test_circular_references(self):
         models = serializer.serialize(DjangoQLSchema(Book))['models']
-        # If Book references Author then Author shouldn't reference Book back
+        # If Book references Author then Author should also reference Book back
         book_author_field = models['core.book'].get('author')
         self.assertIsNotNone(book_author_field)
         self.assertEqual('relation', book_author_field['type'])
         self.assertEqual('auth.user', book_author_field['relation'])
-        self.assertNotIn('book', models['auth.user'])
+        self.assertEqual('relation', models['auth.user']['book']['type'])
 
     def test_custom_search(self):
         models = serializer.serialize(BookCustomSearchSchema(Book))['models']


### PR DESCRIPTION
I had the situation where I had the following models:

```
class Base(Model):
    pass

class Sub(Model):
    base = ForeignKey("Base", ...)

class Comment(Model):
    text = TextField()
    base = ForeignKey("Base", related_name="comments", ...)
    sub = ForeignKey("Base", related_name="comments", null=True, ...)

class OurQLSchema(DjangoQLSchema):
    def get_fields(self, model):
        if model == Base:
            return ['comments']
        if model == Sub:
            return ['comments']
        return super(UserQLSchema, self).get_fields(model)
```

In the above example, the query "sub.comments.text" would not work. This is because by the time the schema would try to inspect "sub.comments", it would already have seen the Comment model, would not add the field. I believe this to be incorrect. While the comment model does not need to be reinspected, the field still needs to be added.