### PR TITLE
replaced the deprecated use of re_path alias at django.conf.urls

### DIFF
--- a/djangoql/admin.py
+++ b/djangoql/admin.py
@@ -23,7 +23,7 @@ except ImportError:  # Django 2.0
     from django.urls import reverse
 
 try:
-    from django.conf.urls import re_path
+    from django.urls import re_path
 except ImportError:  # Django <2.0
     from django.conf.urls import url as re_path
 


### PR DESCRIPTION
django.conf.urls.re_path was depricated in django 3.1 in favor of django.urls.re_path() and is removed in django 4.0
ref: https://docs.djangoproject.com/en/4.0/releases/3.1/#deprecated-features-3-1