### PR TITLE
Fix url for multiple sites support

### DIFF
--- a/djangoql/admin.py
+++ b/djangoql/admin.py
@@ -166,7 +166,8 @@ class DjangoQLSearchMixin(object):
         return custom_urls + super(DjangoQLSearchMixin, self).get_urls()
 
     def introspect(self, request):
-        suggestions_url = reverse('admin:%s_%s_djangoql_suggestions' % (
+        suggestions_url = reverse('%s:%s_%s_djangoql_suggestions' % (
+            self.admin_site.name,
             self.model._meta.app_label,
             self.model._meta.model_name,
         ))


### PR DESCRIPTION
Resolve #101

I'm also working with multiple sites and my solution was to use the name of the site according to the admin_site of the class.

This way it could make the app more dynamic and without any negative effects.