### PR TITLE
Serialize empty options to null

### DIFF
--- a/djangoql/serializers.py
+++ b/djangoql/serializers.py
@@ -26,7 +26,7 @@ class DjangoQLSchemaSerializer(object):
         return result
 
     def serialize_field_options(self, field):
-        return list(field.get_options('')) if field.suggest_options else []
+        return list(field.get_options('')) if field.suggest_options else None
 
 
 class SuggestionsAPISerializer(DjangoQLSchemaSerializer):


### PR DESCRIPTION
There is a bug when the completion lib always put `""` to the end of the entered string even if it's a numeric field as `[]` is always `true` https://github.com/ivelum/djangoql-completion/blob/f9cefc3ae3c985c234f91b3fab6f5254e20e14dc/src/index.js#L953C1-L953C1