### PR TITLE
Fix djangoql_syntax_help url in error_message

### DIFF
--- a/djangoql/admin.py
+++ b/djangoql/admin.py
@@ -6,6 +6,7 @@ from django.core.exceptions import FieldError, ValidationError
 from django.db import DataError, NotSupportedError
 from django.forms import Media
 from django.http import HttpResponse
+from django.shortcuts import resolve_url
 from django.template.loader import render_to_string
 from django.views.generic import TemplateView
 
@@ -112,6 +113,9 @@ class DjangoQLSearchMixin(object):
             msg = text_type(exception)
         return render_to_string('djangoql/error_message.html', context={
             'error_message': msg,
+            'djangoql_syntax_help_url': resolve_url(
+                f'{self.admin_site.name}:djangoql_syntax_help'
+            ),
         })
 
     @property

--- a/djangoql/templates/djangoql/error_message.html
+++ b/djangoql/templates/djangoql/error_message.html
@@ -1,6 +1,6 @@
 <div class="clearfix">
   {{ error_message }}
-  <a href="{% url 'admin:djangoql_syntax_help' %}" class="djangoql-help">
+  <a href="{{ djangoql_syntax_help_url }}" class="djangoql-help">
     DjangoQL syntax help
   </a>
 </div>

--- a/test_project/core/tests/test_admin.py
+++ b/test_project/core/tests/test_admin.py
@@ -46,14 +46,17 @@ class DjangoQLAdminTest(TestCase):
             )
 
     def test_djangoql_syntax_help(self):
-        url = reverse('admin:djangoql_syntax_help')
-        # unauthorized request should be redirected
-        response = self.client.get(url)
-        self.assertEqual(302, response.status_code)
-        self.assertTrue(self.client.login(**self.credentials))
-        # authorized request should be served
-        response = self.client.get(url)
-        self.assertEqual(200, response.status_code)
+        for app in ['admin', 'zaibatsu']:
+            url = reverse(f'{app}:djangoql_syntax_help')
+            self.client.logout()
+            with self.subTest(app=app):
+                response = self.client.get(url)
+                # unauthorized request should be redirected
+                self.assertEqual(302, response.status_code)
+                self.assertTrue(self.client.login(**self.credentials))
+                # authorized request should be served
+                response = self.client.get(url)
+                self.assertEqual(200, response.status_code)
 
     def test_suggestions(self):
         url = reverse('admin:core_book_djangoql_suggestions')


### PR DESCRIPTION
This fixes a bug when djangoql is used in another admin and not the default admin.

Error message:
```Reverse for 'djangoql_syntax_help' not found. 'djangoql_syntax_help' is not a valid view function or pattern name.```